### PR TITLE
change route path and generate link href

### DIFF
--- a/src/components/landingpage/body/GenerateLink.js
+++ b/src/components/landingpage/body/GenerateLink.js
@@ -7,7 +7,7 @@ class GenerateLink extends Component {
       <section id="generate-link">
         <div>
           <h2 className="section-title">Generate your link and start collaborating with your team</h2>
-          <a href="/new">Generate Link</a>
+          <a href="/sundial-frontend/new">Generate Link</a>
         </div>
       </section>
     );

--- a/src/index.js
+++ b/src/index.js
@@ -14,8 +14,8 @@ import './index.css'
 ReactDOM.render(
   <Provider store={store}>
     <Router history={browserHistory} >
-      <Route path="/" component={LandingPage} />
-      <Route path="/:sessionid" component={App} />
+      <Route path="/sundial-frontend/" component={LandingPage} />
+      <Route path="/sundial-frontend/:sessionid" component={App} />
     </Router>
   </Provider>,
   document.getElementById('root')


### PR DESCRIPTION
The website keeps showing the schedule page (instead of showing the landing page) because it assumes that the `:session` is `sundial-frontend`.